### PR TITLE
Invalidate calls in CXCallProvider.

### DIFF
--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -56,6 +56,10 @@ RCT_EXPORT_MODULE()
     NSLog(@"[RNCallKit][dealloc]");
 #endif
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    
+    if (self.callKitProvider != nil) {
+        [self.callKitProvider invalidate];
+    }
 }
 
 // Override method of RCTEventEmitter


### PR DESCRIPTION
This will make sure that CallKit isn't being confused when the app is reloaded when developing. Otherwise it would get confused and reject any transaction after the reload.